### PR TITLE
WIP: feat(trakt.tv): set movie information object

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -2,6 +2,9 @@
 <addon id="video.kino.pub" name="kino.pub" version="${VERSION}" provider-name="kino.pub">
   <requires>
     <import addon="xbmc.python" version="2.25.0"/>
+    <!-- To use debugger use `import web_pdb; web_pdb.set_trace()`
+    <import addon="script.module.web-pdb" />
+     -->
   </requires>
   <extension point="xbmc.python.pluginsource" library="addon.py">
     <provides>video</provides>

--- a/resources/lib/addonutils.py
+++ b/resources/lib/addonutils.py
@@ -89,7 +89,7 @@ def video_info(item, extend=None):
         "plot": build_plot(item),
         "title": item["title"],
         "duration": item.get("duration", {}).get("average"),
-        "imdbnumber": "%07d" % (item["imdb"],), # imdb id should be 7 digits with leading zeroes
+        "imdbnumber": "%07d" % (item["imdb"],),  # imdb id should be 7 digits with leading zeroes
         "status": get_status(item),
         "votes": item["rating_votes"],
         "country": ", ".join([x["title"] for x in item["countries"]])

--- a/resources/lib/addonutils.py
+++ b/resources/lib/addonutils.py
@@ -89,7 +89,7 @@ def video_info(item, extend=None):
         "plot": build_plot(item),
         "title": item["title"],
         "duration": item.get("duration", {}).get("average"),
-        "imdbnumber": item["imdb"],
+        "imdbnumber": "%07d" % (item["imdb"],), # imdb id should be 7 digits with leading zeroes
         "status": get_status(item),
         "votes": item["rating_votes"],
         "country": ", ".join([x["title"] for x in item["countries"]])

--- a/resources/lib/addonutils.py
+++ b/resources/lib/addonutils.py
@@ -89,7 +89,7 @@ def video_info(item, extend=None):
         "plot": build_plot(item),
         "title": item["title"],
         "duration": item.get("duration", {}).get("average"),
-        "imdbnumber": "%07d" % (item["imdb"],),  # imdb id should be 7 digits with leading zeroes
+        "imdbnumber": item["imdb"],
         "status": get_status(item),
         "votes": item["rating_votes"],
         "country": ", ".join([x["title"] for x in item["countries"]])

--- a/resources/lib/addonworker.py
+++ b/resources/lib/addonworker.py
@@ -339,7 +339,6 @@ def play(id, title, video_info, video_data=None, poster=None):
         poster=poster,
         subtitles=[subtitle["url"] for subtitle in video_data["subtitles"]],
     )
-    li.setResumeTime(video_info["time"], video_info["duration"])
     li.setUniqueIDs({"imdb": video_info["imdbnumber"]})
     player = Player(list_item=li)
     xbmcplugin.setResolvedUrl(request.handle, True, li)

--- a/resources/lib/addonworker.py
+++ b/resources/lib/addonworker.py
@@ -336,10 +336,14 @@ def play(id, title, video_info, video_data=None, poster=None):
             "season_number": video_info.get("season", ""),
             "playcount": video_info["playcount"]
         },
-        video_info=video_info,
+        video_info={
+            "episode": video_info.get("episode"),
+            "season": video_info.get("season")
+        },
         poster=poster,
         subtitles=[subtitle["url"] for subtitle in video_data["subtitles"]],
     )
+    li.setUniqueIDs({"imdb": video_info["imdbnumber"]})
     player = Player(list_item=li)
     xbmcplugin.setResolvedUrl(request.handle, True, li)
     while player.is_playing:

--- a/resources/lib/addonworker.py
+++ b/resources/lib/addonworker.py
@@ -245,6 +245,7 @@ def episodes(id):
             properties={"id": item["id"], "isPlayable": "true"},
             addContextMenuItems=True
         )
+        li.setResumeTime(watching_episode["time"], watching_episode["duration"])
         link = get_internal_link(
             "play",
             id=item["id"],
@@ -293,6 +294,7 @@ def season_episodes(id, season_number):
             properties={"id": item["id"], "isPlayable": "true"},
             addContextMenuItems=True
         )
+        li.setResumeTime(watching_episode["time"], watching_episode["duration"])
         if watching_episode["status"] < 1 and not selectedEpisode:
             selectedEpisode = True
             li.select(selectedEpisode)

--- a/resources/lib/addonworker.py
+++ b/resources/lib/addonworker.py
@@ -334,9 +334,6 @@ def play(id, title, video_info, video_data=None, poster=None):
             "id": id,
             "play_duration": video_info["duration"],
             "play_resumetime": video_info["time"],
-            "video_number": video_info.get("episode", 1),
-            "season_number": video_info.get("season", ""),
-            "playcount": video_info["playcount"]
         },
         video_info=video_info,
         poster=poster,

--- a/resources/lib/addonworker.py
+++ b/resources/lib/addonworker.py
@@ -336,10 +336,8 @@ def play(id, title, video_info, video_data=None, poster=None):
             "season_number": video_info.get("season", ""),
             "playcount": video_info["playcount"]
         },
-        video_info={
-            "episode": video_info.get("episode"),
-            "season": video_info.get("season")
-        },
+        video_info=video_info,
+        isPlayerInit=True,
         poster=poster,
         subtitles=[subtitle["url"] for subtitle in video_data["subtitles"]],
     )

--- a/resources/lib/addonworker.py
+++ b/resources/lib/addonworker.py
@@ -337,7 +337,6 @@ def play(id, title, video_info, video_data=None, poster=None):
             "playcount": video_info["playcount"]
         },
         video_info=video_info,
-        isPlayerInit=True,
         poster=poster,
         subtitles=[subtitle["url"] for subtitle in video_data["subtitles"]],
     )

--- a/resources/lib/addonworker.py
+++ b/resources/lib/addonworker.py
@@ -336,6 +336,7 @@ def play(id, title, video_info, video_data=None, poster=None):
             "season_number": video_info.get("season", ""),
             "playcount": video_info["playcount"]
         },
+        video_info=video_info,
         poster=poster,
         subtitles=[subtitle["url"] for subtitle in video_data["subtitles"]],
     )

--- a/resources/lib/addonworker.py
+++ b/resources/lib/addonworker.py
@@ -342,6 +342,7 @@ def play(id, title, video_info, video_data=None, poster=None):
         poster=poster,
         subtitles=[subtitle["url"] for subtitle in video_data["subtitles"]],
     )
+    li.setResumeTime(video_info["time"], video_info["duration"])
     li.setUniqueIDs({"imdb": video_info["imdbnumber"]})
     player = Player(list_item=li)
     xbmcplugin.setResolvedUrl(request.handle, True, li)

--- a/resources/lib/listitem.py
+++ b/resources/lib/listitem.py
@@ -24,7 +24,7 @@ class ExtendedListItem(ListItem):
             self.setSubtitles(subtitles)
         if addContextMenuItems:
             self.addPredefinedContextMenuItems()
-        if not isPlayerInit:
+        if not isPlayerInit and video_info and video_info.get("time"):
             # If we will set resume time on li which is sent to Player instance
             # The video's resume time will be set to 0
             self.setResumeTime(video_info.get("time"))

--- a/resources/lib/listitem.py
+++ b/resources/lib/listitem.py
@@ -13,9 +13,7 @@ class ExtendedListItem(ListItem):
 
     def __init__(self, name, label2="", iconImage="", thumbnailImage="", path="", poster=None,
                  video_info=None, properties=None, addContextMenuItems=False, subtitles=None):
-        super(ExtendedListItem, self).__init__(name, label2, iconImage, thumbnailImage, path)  
-        if video_info.get("time"):
-            self.setProperty("resume_time", str(video_info.get("time")))
+        super(ExtendedListItem, self).__init__(name, label2, iconImage, thumbnailImage, path)
         if properties:
             self.setProperties(**properties)
         if video_info:

--- a/resources/lib/listitem.py
+++ b/resources/lib/listitem.py
@@ -18,7 +18,6 @@ class ExtendedListItem(ListItem):
             self.setProperties(**properties)
         if video_info:
             self.setInfo("video", video_info)
-            self.setResumeTime(video_info.get("time"))
         if poster:
             self.setArt({"poster": poster})
         if subtitles:

--- a/resources/lib/listitem.py
+++ b/resources/lib/listitem.py
@@ -12,7 +12,7 @@ class ExtendedListItem(ListItem):
                                                     path)
 
     def __init__(self, name, label2="", iconImage="", thumbnailImage="", path="", poster=None,
-                 video_info=None, properties=None, addContextMenuItems=False, subtitles=None):
+                 video_info=None, properties=None, addContextMenuItems=False, subtitles=None,isPlayerInit=False):
         super(ExtendedListItem, self).__init__(name, label2, iconImage, thumbnailImage, path)
         if properties:
             self.setProperties(**properties)
@@ -24,6 +24,10 @@ class ExtendedListItem(ListItem):
             self.setSubtitles(subtitles)
         if addContextMenuItems:
             self.addPredefinedContextMenuItems()
+        if not isPlayerInit:
+            # If we will set resume time on li which is sent to Player instance
+            # The video's resume time will be set to 0
+            self.setResumeTime(video_info.get("time"))
 
     def _addWatchlistContextMenuItem(self, menu_items):
         in_watchlist = self.getProperty("in_watchlist")

--- a/resources/lib/listitem.py
+++ b/resources/lib/listitem.py
@@ -12,8 +12,10 @@ class ExtendedListItem(ListItem):
                                                     path)
 
     def __init__(self, name, label2="", iconImage="", thumbnailImage="", path="", poster=None,
-                 video_info=None, properties=None, addContextMenuItems=False, subtitles=None,isPlayerInit=False):
-        super(ExtendedListItem, self).__init__(name, label2, iconImage, thumbnailImage, path)
+                 video_info=None, properties=None, addContextMenuItems=False, subtitles=None):
+        super(ExtendedListItem, self).__init__(name, label2, iconImage, thumbnailImage, path)  
+        if video_info.get("time"):
+            self.setProperty("resume_time", str(video_info.get("time")))
         if properties:
             self.setProperties(**properties)
         if video_info:
@@ -24,10 +26,6 @@ class ExtendedListItem(ListItem):
             self.setSubtitles(subtitles)
         if addContextMenuItems:
             self.addPredefinedContextMenuItems()
-        if not isPlayerInit and video_info and video_info.get("time"):
-            # If we will set resume time on li which is sent to Player instance
-            # The video's resume time will be set to 0
-            self.setResumeTime(video_info.get("time"))
 
     def _addWatchlistContextMenuItem(self, menu_items):
         in_watchlist = self.getProperty("in_watchlist")

--- a/resources/lib/player.py
+++ b/resources/lib/player.py
@@ -50,9 +50,9 @@ class Player(xbmc.Player):
 
     def onPlayBackStarted(self):
         # https://github.com/trakt/script.trakt/wiki/Providing-id's-to-facilitate-scrobbling
-        tag = self.list_item.getVideoInfoTag()
+        li = self.list_item
         # imdb id should be 7 digits with leading zeroes with tt prepended
-        imdb_id = "tt%07d" % (int(tag.getIMDBNumber()),)
+        imdb_id = "tt%07d" % (int(li.getUniqueID('imdb')),)
         ids = json.dumps({u'imdb': imdb_id})
         xbmcgui.Window(10000).setProperty('script.trakt.ids', ids)
 

--- a/resources/lib/player.py
+++ b/resources/lib/player.py
@@ -40,9 +40,11 @@ class Player(xbmc.Player):
     @property
     def _base_data(self):
         id = self.list_item.getProperty("id")
-        video_number = str(self.list_item.getVideoInfoTag().getEpisode())
-        season_number = str(self.list_item.getVideoInfoTag().getSeason())
-        if season_number:
+        video_number = self.list_item.getVideoInfoTag().getEpisode()
+        if video_number == -1:
+            video_number = 1
+        season_number = self.list_item.getVideoInfoTag().getSeason()
+        if season_number != -1:
             data = {"id": id, "season": season_number, "video": video_number}
         else:
             data = {"id": id, "video": video_number}

--- a/resources/lib/player.py
+++ b/resources/lib/player.py
@@ -14,12 +14,8 @@ class Player(xbmc.Player):
         self.is_playing = True
         self.marktime = 0
 
-        tag = self.list_item.getVideoInfoTag()
         # https://github.com/trakt/script.trakt/wiki/Providing-id's-to-facilitate-scrobbling
-
-        # TODO for TV shows kinopub gives IMDB ID of the show, not of an episode
-        # For example: https://www.imdb.com/title/tt2085059/
-        # Because of this it can not scrobble TV shows
+        tag = self.list_item.getVideoInfoTag()
         # imdb id should be 7 digits with leading zeroes with tt prepended
         imdb_id = "tt%07d" % (int(tag.getIMDBNumber()),)
         ids = json.dumps({u'imdb': imdb_id})

--- a/resources/lib/player.py
+++ b/resources/lib/player.py
@@ -49,8 +49,13 @@ class Player(xbmc.Player):
         return data
 
     def onPlayBackStarted(self):
-        # https://github.com/trakt/script.trakt/wiki/Providing-id's-to-facilitate-scrobbling
         li = self.list_item
+        # import web_pdb; web_pdb.set_trace()
+        # Not the start of the video => resuming
+        if self.getTime() == 0 and li.getProperty("resume_time"):
+            self.seekTime(int(li.getProperty("resume_time")))
+
+        # https://github.com/trakt/script.trakt/wiki/Providing-id's-to-facilitate-scrobbling
         # imdb id should be 7 digits with leading zeroes with tt prepended
         imdb_id = "tt%07d" % (int(li.getUniqueID('imdb')),)
         ids = json.dumps({u'imdb': imdb_id})

--- a/resources/lib/player.py
+++ b/resources/lib/player.py
@@ -20,8 +20,9 @@ class Player(xbmc.Player):
         # TODO for TV shows kinopub gives IMDB ID of the show, not of an episode
         # For example: https://www.imdb.com/title/tt2085059/
         # Because of this it can not scrobble TV shows
-
-        ids = json.dumps({u'imdb': 'tt' + tag.getIMDBNumber()})
+        # imdb id should be 7 digits with leading zeroes with tt prepended
+        imdb_id = "tt%07d" % (tag.getIMDBNumber(),)
+        ids = json.dumps({u'imdb': imdb_id})
         xbmcgui.Window(10000).setProperty('script.trakt.ids', ids)
 
     def set_marktime(self):

--- a/resources/lib/player.py
+++ b/resources/lib/player.py
@@ -21,7 +21,7 @@ class Player(xbmc.Player):
         # For example: https://www.imdb.com/title/tt2085059/
         # Because of this it can not scrobble TV shows
         # imdb id should be 7 digits with leading zeroes with tt prepended
-        imdb_id = "tt%07d" % (tag.getIMDBNumber(),)
+        imdb_id = "tt%07d" % (int(tag.getIMDBNumber()),)
         ids = json.dumps({u'imdb': imdb_id})
         xbmcgui.Window(10000).setProperty('script.trakt.ids', ids)
 

--- a/resources/lib/player.py
+++ b/resources/lib/player.py
@@ -1,9 +1,7 @@
 # -*- coding: utf-8 -*-
-import xbmc
-import json
+import xbmc,xbmcgui,json
 from client import KinoPubClient
 from data import get_adv_setting
-from resources.lib.modules import control
 
 
 class Player(xbmc.Player):
@@ -57,7 +55,7 @@ class Player(xbmc.Player):
         # Because of this it can not scrobble TV shows
 
         ids = json.dumps({u'imdb': 'tt' + tag.getIMDBNumber()})
-        control.window.setProperty('script.trakt.ids', ids)
+        xbmcgui.Window(10000).setProperty('script.trakt.ids', ids)
 
     def onPlayBackStopped(self):
         self.is_playing = False

--- a/resources/lib/player.py
+++ b/resources/lib/player.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
 import xbmc
-
+import json
 from client import KinoPubClient
 from data import get_adv_setting
+from resources.lib.modules import control
 
 
 class Player(xbmc.Player):
@@ -46,18 +47,17 @@ class Player(xbmc.Player):
         else:
             data = {"id": id, "video": video_number}
         return data
-    
+
     def onPlayBackStarted(self):
         tag = self.list_item.getVideoInfoTag()
-        # trakt.tv info tag: https://github.com/trakt/script.trakt/wiki/Providing-id's-to-facilitate-scrobbling   
-        
+        # https://github.com/trakt/script.trakt/wiki/Providing-id's-to-facilitate-scrobbling
+
         # TODO for TV shows kinopub gives IMDB ID of the show, not of an episode
         # For example: https://www.imdb.com/title/tt2085059/
         # Because of this it can not scrobble TV shows
-        
-        ids = json.dumps({u'imdb': 'tt' + tag.getIMDBNumber()})
-        xbmcgui.Window(10000).setProperty('script.trakt.ids', ids)
 
+        ids = json.dumps({u'imdb': 'tt' + tag.getIMDBNumber()})
+        control.window.setProperty('script.trakt.ids', ids)
 
     def onPlayBackStopped(self):
         self.is_playing = False

--- a/resources/lib/player.py
+++ b/resources/lib/player.py
@@ -40,8 +40,8 @@ class Player(xbmc.Player):
     @property
     def _base_data(self):
         id = self.list_item.getProperty("id")
-        video_number = self.list_item.getProperty("video_number")
-        season_number = self.list_item.getProperty("season_number")
+        video_number = str(self.list_item.getVideoInfoTag().getEpisode())
+        season_number = str(self.list_item.getVideoInfoTag().getSeason())
         if season_number:
             data = {"id": id, "season": season_number, "video": video_number}
         else:
@@ -63,7 +63,7 @@ class Player(xbmc.Player):
         if self.should_make_resume_point:
             data["time"] = self.marktime
             KinoPubClient("watching/marktime").get(data=data)
-        elif self.should_mark_as_watched and int(self.list_item.getProperty("playcount")) < 1:
+        elif self.should_mark_as_watched and self.list_item.getVideoInfoTag().getPlayCount() < 1:
             data["status"] = 1
             KinoPubClient("watching/toggle").get(data=data)
         elif self.should_reset_resume_point:
@@ -74,7 +74,7 @@ class Player(xbmc.Player):
 
     def onPlayBackEnded(self):
         self.is_playing = False
-        if int(self.list_item.getProperty("playcount")) < 1:
+        if self.list_item.getVideoInfoTag().getPlayCount() < 1:
             data = self._base_data
             data["status"] = 1
             KinoPubClient("watching/toggle").get(data=data)

--- a/resources/lib/player.py
+++ b/resources/lib/player.py
@@ -14,6 +14,16 @@ class Player(xbmc.Player):
         self.is_playing = True
         self.marktime = 0
 
+        tag = self.list_item.getVideoInfoTag()
+        # https://github.com/trakt/script.trakt/wiki/Providing-id's-to-facilitate-scrobbling
+
+        # TODO for TV shows kinopub gives IMDB ID of the show, not of an episode
+        # For example: https://www.imdb.com/title/tt2085059/
+        # Because of this it can not scrobble TV shows
+
+        ids = json.dumps({u'imdb': 'tt' + tag.getIMDBNumber()})
+        xbmcgui.Window(10000).setProperty('script.trakt.ids', ids)
+
     def set_marktime(self):
         if self.isPlaying():
             self.marktime = int(self.getTime())
@@ -47,17 +57,6 @@ class Player(xbmc.Player):
         else:
             data = {"id": id, "video": video_number}
         return data
-
-    def onPlayBackStarted(self):
-        tag = self.list_item.getVideoInfoTag()
-        # https://github.com/trakt/script.trakt/wiki/Providing-id's-to-facilitate-scrobbling
-
-        # TODO for TV shows kinopub gives IMDB ID of the show, not of an episode
-        # For example: https://www.imdb.com/title/tt2085059/
-        # Because of this it can not scrobble TV shows
-
-        ids = json.dumps({u'imdb': 'tt' + tag.getIMDBNumber()})
-        xbmcgui.Window(10000).setProperty('script.trakt.ids', ids)
 
     def onPlayBackStopped(self):
         self.is_playing = False

--- a/resources/lib/player.py
+++ b/resources/lib/player.py
@@ -50,10 +50,6 @@ class Player(xbmc.Player):
 
     def onPlayBackStarted(self):
         li = self.list_item
-        # import web_pdb; web_pdb.set_trace()
-        # Not the start of the video => resuming
-        if self.getTime() == 0 and li.getProperty("resume_time"):
-            self.seekTime(int(li.getProperty("resume_time")))
 
         # https://github.com/trakt/script.trakt/wiki/Providing-id's-to-facilitate-scrobbling
         # imdb id should be 7 digits with leading zeroes with tt prepended

--- a/resources/lib/player.py
+++ b/resources/lib/player.py
@@ -46,6 +46,18 @@ class Player(xbmc.Player):
         else:
             data = {"id": id, "video": video_number}
         return data
+    
+    def onPlayBackStarted(self):
+        tag = self.list_item.getVideoInfoTag()
+        # trakt.tv info tag: https://github.com/trakt/script.trakt/wiki/Providing-id's-to-facilitate-scrobbling   
+        
+        # TODO for TV shows kinopub gives IMDB ID of the show, not of an episode
+        # For example: https://www.imdb.com/title/tt2085059/
+        # Because of this it can not scrobble TV shows
+        
+        ids = json.dumps({u'imdb': 'tt' + tag.getIMDBNumber()})
+        xbmcgui.Window(10000).setProperty('script.trakt.ids', ids)
+
 
     def onPlayBackStopped(self):
         self.is_playing = False

--- a/resources/lib/player.py
+++ b/resources/lib/player.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
-import xbmc,xbmcgui,json
+import xbmc
+import xbmcgui
+import json
 from client import KinoPubClient
 from data import get_adv_setting
 

--- a/resources/lib/player.py
+++ b/resources/lib/player.py
@@ -14,13 +14,6 @@ class Player(xbmc.Player):
         self.is_playing = True
         self.marktime = 0
 
-        # https://github.com/trakt/script.trakt/wiki/Providing-id's-to-facilitate-scrobbling
-        tag = self.list_item.getVideoInfoTag()
-        # imdb id should be 7 digits with leading zeroes with tt prepended
-        imdb_id = "tt%07d" % (int(tag.getIMDBNumber()),)
-        ids = json.dumps({u'imdb': imdb_id})
-        xbmcgui.Window(10000).setProperty('script.trakt.ids', ids)
-
     def set_marktime(self):
         if self.isPlaying():
             self.marktime = int(self.getTime())
@@ -54,6 +47,14 @@ class Player(xbmc.Player):
         else:
             data = {"id": id, "video": video_number}
         return data
+
+    def onPlayBackStarted(self):
+        # https://github.com/trakt/script.trakt/wiki/Providing-id's-to-facilitate-scrobbling
+        tag = self.list_item.getVideoInfoTag()
+        # imdb id should be 7 digits with leading zeroes with tt prepended
+        imdb_id = "tt%07d" % (int(tag.getIMDBNumber()),)
+        ids = json.dumps({u'imdb': imdb_id})
+        xbmcgui.Window(10000).setProperty('script.trakt.ids', ids)
 
     def onPlayBackStopped(self):
         self.is_playing = False

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -183,9 +183,6 @@ def test_play(play, main, ExtendedListItem, xbmcplugin):
             "id": str(actionPlay_response["item"]["id"]),
             "play_duration": 0,
             "play_resumetime": 0,
-            "video_number": 1,
-            "season_number": "",
-            "playcount": 0
         },
         poster=None,
         subtitles=[],

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -171,7 +171,6 @@ def play(request, mocker, settings):
 
 
 def test_play(play, main, ExtendedListItem, xbmcplugin):
-    from resources.lib.addonutils import build_plot
     stream, video_quality = play
     main()
     title = actionPlay_response["item"]["title"].encode("utf-8")
@@ -190,23 +189,12 @@ def test_play(play, main, ExtendedListItem, xbmcplugin):
         poster=None,
         subtitles=[],
         video_info={
-            "status": None,
-            "rating": 3.0,
-            u'time': 0,
-            "title": actionPlay_response["item"]["title"],
-            "votes": actionPlay_response["item"]["rating_votes"],
-            "year": actionPlay_response["item"]["year"],
-            "cast": [x.strip() for x in actionPlay_response["item"]["cast"].split(",")],
-            "country": ", ".join([x["title"] for x in actionPlay_response["item"]["countries"]]),
-            "director": actionPlay_response["item"]["director"],
-            "duration": 0,
-            "genre": ", ".join([x["title"] for x in actionPlay_response["item"]["genres"]]),
-            u'playcount': 0,
-            "imdbnumber": actionPlay_response["item"]["imdb"],
-            "plot": build_plot(actionPlay_response["item"])
+            "episode": None,
+            "season": None
         }
     )
     li = ExtendedListItem(title, path=link)
+    li.setUniqueIDs.assert_called_with({"imdb": actionPlay_response["item"]["imdb"]})
     xbmcplugin.setResolvedUrl.assert_called_once_with(handle, True, li)
 
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -171,6 +171,7 @@ def play(request, mocker, settings):
 
 
 def test_play(play, main, ExtendedListItem, xbmcplugin):
+    from resources.lib.addonutils import build_plot
     stream, video_quality = play
     main()
     title = actionPlay_response["item"]["title"].encode("utf-8")
@@ -189,8 +190,20 @@ def test_play(play, main, ExtendedListItem, xbmcplugin):
         poster=None,
         subtitles=[],
         video_info={
-            "episode": None,
-            "season": None
+            "status": None,
+            "rating": 3.0,
+            u'time': 0,
+            "title": actionPlay_response["item"]["title"],
+            "votes": actionPlay_response["item"]["rating_votes"],
+            "year": actionPlay_response["item"]["year"],
+            "cast": [x.strip() for x in actionPlay_response["item"]["cast"].split(",")],
+            "country": ", ".join([x["title"] for x in actionPlay_response["item"]["countries"]]),
+            "director": actionPlay_response["item"]["director"],
+            "duration": 0,
+            "genre": ", ".join([x["title"] for x in actionPlay_response["item"]["genres"]]),
+            u'playcount': 0,
+            "imdbnumber": actionPlay_response["item"]["imdb"],
+            "plot": build_plot(actionPlay_response["item"])
         }
     )
     li = ExtendedListItem(title, path=link)

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -171,6 +171,7 @@ def play(request, mocker, settings):
 
 
 def test_play(play, main, ExtendedListItem, xbmcplugin):
+    from resources.lib.addonutils import build_plot
     stream, video_quality = play
     main()
     title = actionPlay_response["item"]["title"].encode("utf-8")
@@ -187,7 +188,23 @@ def test_play(play, main, ExtendedListItem, xbmcplugin):
             "playcount": 0
         },
         poster=None,
-        subtitles=[]
+        subtitles=[],
+        video_info={
+            "status": None,
+            "rating": 3.0,
+            u'time': 0,
+            "title": actionPlay_response["item"]["title"],
+            "votes": actionPlay_response["item"]["rating_votes"],
+            "year": actionPlay_response["item"]["year"],
+            "cast": [x.strip() for x in actionPlay_response["item"]["cast"].split(",")],
+            "country": ", ".join([x["title"] for x in actionPlay_response["item"]["countries"]]),
+            "director": actionPlay_response["item"]["director"],
+            "duration": 0,
+            "genre": ", ".join([x["title"] for x in actionPlay_response["item"]["genres"]]),
+            u'playcount': 0,
+            "imdbnumber": actionPlay_response["item"]["imdb"],
+            "plot": build_plot(actionPlay_response["item"])
+        }
     )
     li = ExtendedListItem(title, path=link)
     xbmcplugin.setResolvedUrl.assert_called_once_with(handle, True, li)


### PR DESCRIPTION
Есть сервис для скробблинга просмотренных фильмов и сериалов [Trakt.tv](https://trakt.tv).

У них есть [плагин для Kodi](https://github.com/trakt/script.trakt), который отправляет все просмотренное в Trakt.tv и позволяет поставить оценку просмотренному.

Выглядит это вот так:

![Rating](http://i.imgur.com/7IayOWr.png)

Если смотрим фильмы и сериалы через плагин Kino.pub, Trakt.tv не узнает об этом по понятным причинам.

Я хочу реализовать сам такой функционал в плагине, но я в жизни не касался разработки плагина для Kodi, поэтому сначала хотел уточнить как лучше и как вообще возможно это сделать.

Я вижу три варианта:

1. Сделать что-то, что позволит нам работать с родным плагином trakt.tv. Или сделать так, чтобы плагин сам видел, что мы смотрели. Или может быть вызывать какой-то публичный метод плагина trakt?
Из документации: `Add-ons that stream content need to correctly identify TV episodes and movies with as much metadata as possible for Trakt to know what you're watching.` `...` `TV shows are identified by TVDb ID or IMDb ID. Movies are identified by TMDb ID or IMDb ID. This allows Trakt to match the correct show or movie more accurately, regardless of the title. The best supported and recommended configuration is to use TVDb (for tv shows) and TMDb (for movies) as your scrapers.`  То есть может быть нам всего лишь не хватает метаданных TMDb/IMDb/TVDb?

2. Сделать свой скробблинг в trakt внутри плагина. То есть в настройках кинопроб плагина будет аутенфикация в trakt, и плагин сам будет делать запрос в их API. Звучит как сложно и не нужно.

3. На худой конец есть ли у кинопаба API, который выдает информацию о просмотренном пользователем? Если так, то на худой конец я готов написать просто внешний daemon, который будет крутится у меня на сервере, забирать информацию с кинопаба и отправлять в trakt.

Что думаете? Насколько это возможно и с чего начать?