### PR TITLE
WIP: HLS4 support

### DIFF
--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -2,7 +2,7 @@
 <settings>
     <category label="Общие">
         <setting id="video_quality" type="select" label="Качество видео" values="1080p|720p|480p" enable="eq(2,false)" default="1080p"/>
-        <setting id="stream_type" type="select" label="Тип стриминга" values="http|hls|hls2" enable="eq(1,false)" default="hls"/>
+        <setting id="stream_type" type="select" label="Тип стриминга" values="http|hls|hls2|hls4" enable="eq(1,false)" default="hls"/>
         <setting id="ask_quality" type="bool" label="Задавать вопрос о качестве видео перед воспроизведением" default="false"/>
         <setting type="sep" />
         <setting id="reset_auth" type="bool" label="Сбросить аутентификацию" default="false"/>


### PR DESCRIPTION
Переношу обсуждение из #39.

Меня вопрос протокола очень сильно интересует, так как использовать более оптимизированный протокол для меня было бы очень кстати, ибо до нашей деревени HTTP поток в 1080p долетает очень плохо.

Вопрос лишь в том, действительно ли может быть bottle neck в этом месте, но если есть информация о том, что HTTP потом искусственно ограничен, то я решил разобраться с поддержкой HSL4.

Вероятно эту дискуссию стоит переносить в отдельное issue, если действительно есть возможность реализовать просмотр через HSL4 поток. Я понимаю, что по сравнению с HSL2 нет никакого прироста в скорости, ибо контейнер то один и тот же, но с HSL2 мы теряем выбор аудиодорожки (судя по информации на кинопабе), поэтому для меня эта тема важна.

Я пошел почитать вообще про HSL и про разницу в протоколах.
HSL4 отличается от предыдущей версии следующим:

- Segments with bit range support with tag EXT-X-BYTERANGE
- Support for fast forward and fast rewind with tags EXT-X-I-FRAMES-ONLY and EXT-X-I-FRAME-STREAM-INF
- Alternate media option with tag EXT-X-MEDIA (я так понимаю, это самое важное для нас, то есть в плейлисте есть сразу все варианты видео, и становится возможен адаптивный выбор качества)

Я пошел почитать [сырцы текущей версии реализации hls в ffmpeg](https://github.com/FFmpeg/FFmpeg/blob/master/libavformat/hls.c) и там есть поддержка всех этих тегов (добавлена еще в 2014-м).

Плюс на [странице документации ffmpeg](https://ffmpeg.org/ffmpeg-formats.html) в разделе `hls_flags` в разделе `single_file` есть следующее сообщение: `HLS playlists generated with this way will have the version number 4`. То есть генерацию HLS плейлиста версии 4 он явно поддерживает.

Я пока что дальше не буду копать, так как могу много не понимать и в разработке Kodi плагина совсем еще зеленый, но, если все таки есть шанс, что оно все таки поддерживается, готов с радостью продолжить research на эту тему в рамках отдельного issue. А в этом вернусь к реализации спидтеста.