### PR TITLE
Trakt.tv info set up

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -2,6 +2,9 @@
 <addon id="video.kino.pub" name="kino.pub" version="${VERSION}" provider-name="kino.pub">
   <requires>
     <import addon="xbmc.python" version="2.25.0"/>
+    <!-- To use debugger use `import web_pdb; web_pdb.set_trace()`
+     <import addon="script.module.web-pdb" />
+    -->
   </requires>
   <extension point="xbmc.python.pluginsource" library="addon.py">
     <provides>video</provides>

--- a/addon.xml
+++ b/addon.xml
@@ -2,9 +2,6 @@
 <addon id="video.kino.pub" name="kino.pub" version="${VERSION}" provider-name="kino.pub">
   <requires>
     <import addon="xbmc.python" version="2.25.0"/>
-    <!-- To use debugger use `import web_pdb; web_pdb.set_trace()`
-     <import addon="script.module.web-pdb" />
-    -->
   </requires>
   <extension point="xbmc.python.pluginsource" library="addon.py">
     <provides>video</provides>

--- a/resources/lib/addonworker.py
+++ b/resources/lib/addonworker.py
@@ -334,7 +334,8 @@ def play(id, title, video_info, video_data=None, poster=None):
             "play_resumetime": video_info["time"],
             "video_number": video_info.get("episode", 1),
             "season_number": video_info.get("season", ""),
-            "playcount": video_info["playcount"]
+            "playcount": video_info["playcount"],
+            "imdbnumber": video_info["imdbnumber"]
         },
         poster=poster,
         subtitles=[subtitle["url"] for subtitle in video_data["subtitles"]],

--- a/resources/lib/player.py
+++ b/resources/lib/player.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import xbmc
-
+import json
+import xbmcgui
 from client import KinoPubClient
 from data import get_adv_setting
 
@@ -46,6 +47,15 @@ class Player(xbmc.Player):
         else:
             data = {"id": id, "video": video_number}
         return data
+
+    def onPlayBackStarted(self):
+        li = self.list_item
+
+        # https://github.com/trakt/script.trakt/wiki/Providing-id's-to-facilitate-scrobbling
+        # imdb id should be 7 digits with leading zeroes with tt prepended
+        imdb_id = "tt%07d" % (int(li.getProperty('imdbnumber')),)
+        ids = json.dumps({u'imdb': imdb_id})
+        xbmcgui.Window(10000).setProperty('script.trakt.ids', ids)
 
     def onPlayBackStopped(self):
         self.is_playing = False

--- a/resources/lib/player.py
+++ b/resources/lib/player.py
@@ -53,7 +53,7 @@ class Player(xbmc.Player):
 
         # https://github.com/trakt/script.trakt/wiki/Providing-id's-to-facilitate-scrobbling
         # imdb id should be 7 digits with leading zeroes with tt prepended
-        imdb_id = "tt%07d" % (int(li.getProperty('imdbnumber')),)
+        imdb_id = "tt{:07d}".format(int(li.getProperty("imdbnumber")))
         ids = json.dumps({u'imdb': imdb_id})
         xbmcgui.Window(10000).setProperty('script.trakt.ids', ids)
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -184,7 +184,8 @@ def test_play(play, main, ExtendedListItem, xbmcplugin):
             "play_resumetime": 0,
             "video_number": 1,
             "season_number": "",
-            "playcount": 0
+            "playcount": 0,
+            "imdbnumber": actionPlay_response["item"]["imdb"]
         },
         poster=None,
         subtitles=[]


### PR DESCRIPTION
Resolves #37 

Нашел [документация для авторов стриминговых плагинов](https://github.com/trakt/script.trakt/wiki/Providing-id's-to-facilitate-scrobbling)

Перед воспроизведением медиа нам надо добавить следующий код:
```
ids = json.dumps({u'tmdb': 264660, u'imdb': u'tt0470752', u'slug': u'ex-machina-2014', u'trakt': 163375})
xbmcgui.Window(10000).setProperty('script.trakt.ids', ids)
```

Список ID'шников может быть сильно меньше

Этот PR не использует `video_info` в `play` методе, поэтому нет проблем с воспроизведением с последней точки.