### PR TITLE
Handle expired refresh_token

### DIFF
--- a/src/resources/lib/auth.py
+++ b/src/resources/lib/auth.py
@@ -82,7 +82,7 @@ class Auth(object):
             if e.code == 400:
                 response = json.loads(e.read())
                 error = response.get("error")
-                if error and error in ["code_expired", "authorization_expired"]:
+                if error and error in ["code_expired", "authorization_expired", "invalid_refresh_token"]:
                     raise AuthExpiredException
                 if error and error == "authorization_pending":
                     raise AuthPendingException

--- a/src/resources/lib/auth.py
+++ b/src/resources/lib/auth.py
@@ -82,7 +82,11 @@ class Auth(object):
             if e.code == 400:
                 response = json.loads(e.read())
                 error = response.get("error")
-                if error and error in ["code_expired", "authorization_expired", "invalid_refresh_token"]:
+                if error and error in [
+                    "code_expired",
+                    "authorization_expired",
+                    "invalid_refresh_token",
+                ]:
                     raise AuthExpiredException
                 if error and error == "authorization_pending":
                     raise AuthPendingException


### PR DESCRIPTION
Hello

I experienced the auth error like that
```
2021-12-22 00:30:38.944 T:6233     INFO <general>: [video.kino.pub]: sending payload {'grant_type': 'refresh_token', 'refresh_token': 'xxxxxxxxxx', 'client_id': 'xbmc', 'client_secret': 'xxxxxxxxxx'} to oauth api
2021-12-22 00:30:39.183 T:6233    ERROR <general>: EXCEPTION Thrown (PythonToCppException) : -->Python callback/script returned the following error<--
                                                    - NOTE: IGNORING THIS CAN LEAD TO MEMORY LEAKS!
                                                   Error Type: <class 'resources.lib.auth.AuthException'>
                                                   Error Contents: invalid_refresh_token
                                                   Traceback (most recent call last):
                                                     File "/home/osmc/.kodi/addons/video.kino.pub/resources/lib/client.py", line 25, in _make_request
                                                       response = urllib.request.urlopen(request, timeout=timeout)
                                                     File "/usr/lib/python3.7/urllib/request.py", line 222, in urlopen
                                                       return opener.open(url, data, timeout)
                                                     File "/usr/lib/python3.7/urllib/request.py", line 531, in open
                                                       response = meth(req, response)
                                                     File "/usr/lib/python3.7/urllib/request.py", line 641, in http_response
                                                       'http', request, response, code, msg, hdrs)
                                                     File "/usr/lib/python3.7/urllib/request.py", line 569, in error
                                                       return self._call_chain(*args)
                                                     File "/usr/lib/python3.7/urllib/request.py", line 503, in _call_chain
                                                       result = func(*args)
                                                     File "/usr/lib/python3.7/urllib/request.py", line 649, in http_error_default
                                                       raise HTTPError(req.full_url, code, msg, hdrs, fp)
                                                   urllib.error.HTTPError: HTTP Error 401: Unauthorized

                                                   During handling of the above exception, another exception occurred:

                                                   Traceback (most recent call last):
                                                     File "/home/osmc/.kodi/addons/video.kino.pub/resources/lib/auth.py", line 78, in _make_request
                                                       urllib.parse.urlencode(payload).encode("utf-8"),
                                                     File "/usr/lib/python3.7/urllib/request.py", line 222, in urlopen
                                                       return opener.open(url, data, timeout)
                                                     File "/usr/lib/python3.7/urllib/request.py", line 531, in open
                                                       response = meth(req, response)
                                                     File "/usr/lib/python3.7/urllib/request.py", line 641, in http_response
                                                       'http', request, response, code, msg, hdrs)
                                                     File "/usr/lib/python3.7/urllib/request.py", line 569, in error
                                                       return self._call_chain(*args)
                                                     File "/usr/lib/python3.7/urllib/request.py", line 503, in _call_chain
                                                       result = func(*args)
                                                     File "/usr/lib/python3.7/urllib/request.py", line 649, in http_error_default
                                                       raise HTTPError(req.full_url, code, msg, hdrs, fp)
                                                   urllib.error.HTTPError: HTTP Error 400: Bad Request

                                                   During handling of the above exception, another exception occurred:

                                                   Traceback (most recent call last):
                                                     File "/home/osmc/.kodi/addons/video.kino.pub/addon.py", line 6, in <module>
                                                       plugin.run()
                                                     File "/home/osmc/.kodi/addons/video.kino.pub/resources/lib/plugin.py", line 81, in run
                                                       self.routing.dispatch(self.path)
                                                     File "/home/osmc/.kodi/addons/video.kino.pub/resources/lib/routing.py", line 62, in dispatch
                                                       view_func(**kwargs)
                                                     File "/home/osmc/.kodi/addons/video.kino.pub/resources/lib/main.py", line 305, in bookmarks
                                                       response = plugin.client("bookmarks").get()
                                                     File "/home/osmc/.kodi/addons/video.kino.pub/resources/lib/client.py", line 50, in get
                                                       return self._make_request(request)
                                                     File "/home/osmc/.kodi/addons/video.kino.pub/resources/lib/client.py", line 29, in _make_request
                                                       self.plugin.auth.get_token()
                                                     File "/home/osmc/.kodi/addons/video.kino.pub/resources/lib/auth.py", line 204, in get_token
                                                       self._refresh_token()
                                                     File "/home/osmc/.kodi/addons/video.kino.pub/resources/lib/auth.py", line 140, in _refresh_token
                                                       resp = self._make_request(payload)
                                                     File "/home/osmc/.kodi/addons/video.kino.pub/resources/lib/auth.py", line 91, in _make_request
                                                       raise AuthException(error)
                                                   resources.lib.auth.AuthException: invalid_refresh_token
                                                   -->End of Python script error report<--

2021-12-22 00:30:39.484 T:6233     INFO <general>: Python interpreter stopped
```

With adding some debug info:
```
021-12-22 00:40:06.952 T:6590     INFO <general>: [video.kino.pub]: sending payload {'grant_type': 'refresh_token', 'refresh_token': 'xxxxxxxxxx', 'client_id': 'xbmc', 'client_secret': 'xxxxxxxxxx'} to oauth api
2021-12-22 00:40:07.169 T:6590     INFO <general>: [video.kino.pub]: oauth api response {'status': 400, 'error': 'invalid_refresh_token'}
```

So, I've added also handling this case to refreshing auth. Not too comfortable (it requires to go to web ui and re-add device again) but more user-friendly than resetting auth.