### PR TITLE
Prevent 403-response from api-server

### DIFF
--- a/src/resources/lib/auth.py
+++ b/src/resources/lib/auth.py
@@ -78,8 +78,11 @@ class Auth:
     def _make_request(self, payload):
         self.plugin.logger.debug(f"Sending payload {payload} to oauth api")
         try:
+            headers = {
+                "user-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36"
+            }
             response = urllib.request.urlopen(
-                urllib.request.Request(self.plugin.settings.oauth_api_url),
+                urllib.request.Request(self.plugin.settings.oauth_api_url, headers=headers),
                 urllib.parse.urlencode(payload).encode("utf-8"),
             ).read()
             return json.loads(response)

--- a/src/resources/lib/auth.py
+++ b/src/resources/lib/auth.py
@@ -79,7 +79,8 @@ class Auth:
         self.plugin.logger.debug(f"Sending payload {payload} to oauth api")
         try:
             headers = {
-                "user-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36"
+                "user-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+                              "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36"
             }
             response = urllib.request.urlopen(
                 urllib.request.Request(self.plugin.settings.oauth_api_url, headers=headers),

--- a/src/resources/lib/auth.py
+++ b/src/resources/lib/auth.py
@@ -80,7 +80,7 @@ class Auth:
         try:
             headers = {
                 "user-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
-                              "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36"
+                "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36"
             }
             response = urllib.request.urlopen(
                 urllib.request.Request(self.plugin.settings.oauth_api_url, headers=headers),

--- a/src/resources/lib/client.py
+++ b/src/resources/lib/client.py
@@ -34,6 +34,8 @@ class KinoApiRequestProcessor(urllib.request.BaseHandler):
             f"Sending {request.get_method()} request to {request.get_full_url()}"
         )
         request.add_header("Authorization", f"Bearer {self.plugin.settings.access_token}")
+        request.add_header("user-agent",
+                           "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36")
         return request
 
     http_request = https_request
@@ -138,6 +140,8 @@ class KinoPubClient:
     def _make_request(self, request: urllib.request.Request) -> Dict[str, Any]:
         request.recursion_counter_401 = 0  # type: ignore[attr-defined]
         request.recursion_counter_429 = 0  # type: ignore[attr-defined]
+        request.add_header("user-agent",
+                           "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36")
         try:
             response = self.opener.open(request, timeout=TIMEOUT)
         except Exception:

--- a/src/resources/lib/client.py
+++ b/src/resources/lib/client.py
@@ -36,7 +36,8 @@ class KinoApiRequestProcessor(urllib.request.BaseHandler):
         request.add_header("Authorization", f"Bearer {self.plugin.settings.access_token}")
         request.add_header(
             "user-agent",
-            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36",
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+            "(KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36",
         )
         return request
 
@@ -144,7 +145,8 @@ class KinoPubClient:
         request.recursion_counter_429 = 0  # type: ignore[attr-defined]
         request.add_header(
             "user-agent",
-            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36",
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+            "(KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36",
         )
         try:
             response = self.opener.open(request, timeout=TIMEOUT)

--- a/src/resources/lib/client.py
+++ b/src/resources/lib/client.py
@@ -34,8 +34,10 @@ class KinoApiRequestProcessor(urllib.request.BaseHandler):
             f"Sending {request.get_method()} request to {request.get_full_url()}"
         )
         request.add_header("Authorization", f"Bearer {self.plugin.settings.access_token}")
-        request.add_header("user-agent",
-                           "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36")
+        request.add_header(
+            "user-agent",
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36",
+        )
         return request
 
     http_request = https_request
@@ -140,8 +142,10 @@ class KinoPubClient:
     def _make_request(self, request: urllib.request.Request) -> Dict[str, Any]:
         request.recursion_counter_401 = 0  # type: ignore[attr-defined]
         request.recursion_counter_429 = 0  # type: ignore[attr-defined]
-        request.add_header("user-agent",
-                           "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36")
+        request.add_header(
+            "user-agent",
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36",
+        )
         try:
             response = self.opener.open(request, timeout=TIMEOUT)
         except Exception:


### PR DESCRIPTION
Use browser user-agent to prevent 403 response from api-server.
This fix the This fixes #313 issue.