### PR TITLE
Fix Russian translation

### DIFF
--- a/src/resources/language/resource.language.ru_ru/strings.po
+++ b/src/resources/language/resource.language.ru_ru/strings.po
@@ -225,11 +225,11 @@ msgid "Movies"
 msgstr "Фильмы"
 
 msgctxt "#32054"
-msgid "TV Series"
+msgid "TV series"
 msgstr "Сериалы"
 
 msgctxt "#32055"
-msgid "TV Show"
+msgid "TV show"
 msgstr "ТВ шоу"
 
 msgctxt "#32056"


### PR DESCRIPTION
There's no Russian translation for "TV show" and "TV series":
<img width="803" height="246" alt="image" src="https://github.com/user-attachments/assets/b1c56325-bbd4-40c1-8397-f438f1960f67" />
After the fix:
<img width="789" height="238" alt="image" src="https://github.com/user-attachments/assets/85b8a4ef-3ba9-4f05-8316-06119c8eb751" />
