### PR TITLE
Fix Russian translation

### DIFF
--- a/src/resources/language/resource.language.ru_ru/strings.po
+++ b/src/resources/language/resource.language.ru_ru/strings.po
@@ -225,11 +225,11 @@ msgid "Movies"
 msgstr "Фильмы"
 
 msgctxt "#32054"
-msgid "TV Series"
+msgid "TV series"
 msgstr "Сериалы"
 
 msgctxt "#32055"
-msgid "TV Show"
+msgid "TV show"
 msgstr "ТВ шоу"
 
 msgctxt "#32056"


### PR DESCRIPTION
There's no Russian translation for "TV series" and "TV show":
<img width="803" height="246" alt="image" src="https://github.com/user-attachments/assets/23dc89ae-57f4-47d5-9472-7f39aeef80e6" />
After the fix:
<img width="789" height="238" alt="image" src="https://github.com/user-attachments/assets/27e05fd2-2473-443e-95c5-b01aeb7213cc" />
